### PR TITLE
fix: remove stray text causing SyntaxError

### DIFF
--- a/mac_ip_port_parsing/2_ip_parse.py
+++ b/mac_ip_port_parsing/2_ip_parse.py
@@ -49,7 +49,6 @@ def check_mac_on_device(row):
 
         # Возвращаем результат выполнения команды
         return row + [result_ip]
-AdmiA
     except SSHException as e:
         error_msg = f"Ошибка SSH при подключении к {ip}: {e}"
         logging.error(error_msg)


### PR DESCRIPTION
## Summary
- remove stray text in `mac_ip_port_parsing/2_ip_parse.py` to restore exception handling

## Testing
- `python -m py_compile mac_ip_port_parsing/2_ip_parse.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7cdf57f88325af4035fb8f803d18